### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -5,6 +5,8 @@ on:
     tags:
       - 'v*'   # Only run on version tags like v1.0.0
 
+permissions:
+  contents: write
 
 jobs:
   build-wheel:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -4,9 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
   build:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
 
     steps:
     - name: Checkout repository
@@ -48,6 +48,7 @@ jobs:
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
+      content: read
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,8 +2,6 @@ name: Build and Upload Sphinx Docs
 
 on:
   push:
-    branches:
-      - main
   pull_request:
     branches:
       - main
@@ -48,7 +46,7 @@ jobs:
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
-      content: read
+      contents: read
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -46,7 +46,7 @@ jobs:
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
-      contents: read
+      contents: write
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -2,6 +2,8 @@ name: Build and Upload Sphinx Docs
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -46,7 +48,7 @@ jobs:
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
-      contents: write
+      contents: read
 
     # Deploy to the github-pages environment
     environment:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
     - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/gregmolskow/SmartHomeUtils/security/code-scanning/2](https://github.com/gregmolskow/SmartHomeUtils/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the `build` job in the workflow file. Since the `build` job does not require write access, we can set the permissions to `contents: read`, which is the minimal permission required for most CI workflows. This ensures that the `GITHUB_TOKEN` has limited access and adheres to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
